### PR TITLE
Makefile: inherit docker user from host user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,19 @@
 build:
-	docker run -t -v "${PWD}":/root/berrymuch -u $(id -u):$(id -g) yamsergey/bb10-ndk:0.5 /bin/bash -c 'cd /root/berrymuch; ./build.sh -b /root/bbndk -t build'
+	docker run -t -v "${PWD}":/root/berrymuch -u $(shell id -u):$(shell id -g) yamsergey/bb10-ndk:0.5.2 /bin/bash -c 'cd /berrymuch; ./build.sh -b /root/bbndk -t build'
 
-shell:
-	docker run -it -v "${PWD}":/root/berrymuch -u $(id -u):$(id -g) yamsergey/bb10-ndk:0.5 /bin/bash
+shell: groupadd useradd
+	docker run -it -v /Big:/Big -v "${PWD}":/berrymuch -u $(shell id -u):$(shell id -g) yamsergey/bb10-ndk:0.5.2 /bin/bash
+
+groupadd:
+	-@docker rm /yamsergey/bb10-ndk:0.5.1 /yam_groupadd 2> /dev/null
+	docker run -it --name yam_groupadd -v "${PWD}":/root/berrymuch yamsergey/bb10-ndk:0.5 /usr/sbin/groupadd kalou --gid $(shell id -g)
+	docker commit yam_groupadd yamsergey/bb10-ndk:0.5.1
+	touch groupadd
+
+useradd: groupadd
+	-@docker rm /yamsergey/bb10-ndk:0.5.2 /yam_useradd 2> /dev/null
+	docker run -it --name yam_useradd yamsergey/bb10-ndk:0.5.1 /usr/sbin/useradd -M $(shell whoami) --uid $(shell id -u) --gid $(shell id -g) -d /berrymuch
+	docker commit yam_useradd yamsergey/bb10-ndk:0.5.2
+	touch useradd
+
 

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,16 @@
 build:
 	docker run -t -v "${PWD}":/root/berrymuch -u $(shell id -u):$(shell id -g) yamsergey/bb10-ndk:0.5.2 /bin/bash -c 'cd /berrymuch; ./build.sh -b /root/bbndk -t build'
 
-shell: groupadd useradd
+shell: useradd
 	docker run -it -v /Big:/Big -v "${PWD}":/berrymuch -u $(shell id -u):$(shell id -g) yamsergey/bb10-ndk:0.5.2 /bin/bash
 
-groupadd:
-	-@docker rm /yamsergey/bb10-ndk:0.5.1 /yam_groupadd 2> /dev/null
+useradd:
+	-@docker rm /yamsergey/bb10-ndk:0.5.1 /yam_useradd /yam_groupadd 2> /dev/null
 	docker run -it --name yam_groupadd -v "${PWD}":/root/berrymuch yamsergey/bb10-ndk:0.5 /usr/sbin/groupadd kalou --gid $(shell id -g)
 	docker commit yam_groupadd yamsergey/bb10-ndk:0.5.1
-	touch groupadd
-
-useradd: groupadd
-	-@docker rm /yamsergey/bb10-ndk:0.5.2 /yam_useradd 2> /dev/null
 	docker run -it --name yam_useradd yamsergey/bb10-ndk:0.5.1 /usr/sbin/useradd -M $(shell whoami) --uid $(shell id -u) --gid $(shell id -g) -d /berrymuch
 	docker commit yam_useradd yamsergey/bb10-ndk:0.5.2
 	touch useradd
+
 
 


### PR DESCRIPTION
In the following PR, I propose to:
 - get the user from host (using $(shell id -u) in Makefile context)
 - get the group from host (using $(shell id -g) in Makefile context)

- create an intermediate image yamsergey/bb10-ndk:0.5.1 created from container "yam_groupadd"
- create the final image yamsergey/bb10-ndk:0.5.2 with:

/berrymuch as home directory for <host_user>