### PR TITLE
Add zlib1g-dev to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN apt-get -yq install \
     libxtst6 \
     net-tools \
     lzip \
-    g++ 
+    g++ \
+    zlib1g-dev 
 
 WORKDIR /root
 


### PR DESCRIPTION
Add `zlib1g-dev` to support compile of GCC 8.3.

I've added the updated image to the Docker registry:
https://hub.docker.com/r/yamsergey/bb10-ndk/tags
![image](https://user-images.githubusercontent.com/666661/97956544-3ae9a000-1da9-11eb-86c8-826fc0416b42.png)
